### PR TITLE
[Fix] Wifi Manager Timeout

### DIFF
--- a/src/communication/wifi/Wifi.cpp
+++ b/src/communication/wifi/Wifi.cpp
@@ -14,10 +14,22 @@ Wifi::Wifi(const char* ssid, QueueHandle_t statusQueue)
 void Wifi::init() {
     ESP_LOGI(WIFI_LOG_TAG, "Initializing WiFi Manager Server and Service...");
     WiFi.mode(WIFI_STA);
+    
+    // Configurations for the WiFi Manager
+    _wifiManager.setConnectTimeout(20);
+    _wifiManager.setConfigPortalTimeout(60);
+
     _wifiManager.autoConnect(_apName);
 
-    ESP_LOGI(WIFI_LOG_TAG, "ESP has been successfully connected to Wifi/Internet");
-    WiFi.begin(); // Save the credential so automatically will connect to last credential that has been connected
+    bool connected = isConnected();
+    if (connected) {
+        ESP_LOGI(WIFI_LOG_TAG, "ESP has been successfully connected to Wifi/Internet: %s", WiFi.SSID().c_str());
+        // WiFi.begin();  // Save the credential so automatically will connect to last credential that has been connected
+    } else {
+        // Failed to connect or user didn't provide credentials
+        ESP_LOGE(WIFI_LOG_TAG, "Failed to connect to WiFi or config portal timed out.");
+    }
+    vTaskDelay(100 / portTICK_PERIOD_MS); // Give enough time so task watchdog can process this 
 }
 
 /**

--- a/src/communication/wifi/Wifi.cpp
+++ b/src/communication/wifi/Wifi.cpp
@@ -54,9 +54,15 @@ bool Wifi::isConnected() {
 bool Wifi::reconnect() {
     if (!isConnected()){
         ESP_LOGW(WIFI_LOG_TAG, "WiFi not connected. Attempting to reconnect...");
+
+        // Reset settings as there's no use for trying to reconnect to last credentials
+        ESP_LOGI(WIFI_LOG_TAG, "Clearing saved credentials to force new configuration.");
+        _wifiManager.resetSettings();
+    
+        ESP_LOGI(WIFI_LOG_TAG, "Launching WiFiManager configuration portal...");
         _wifiManager.autoConnect(_apName);
+
         bool connected = isConnected();
-        updateStatus(connected);
         ESP_LOGI(WIFI_LOG_TAG, "Reconnection result: %s", connected ? "SUCCESS" : "FAILED");
         return true;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,6 +80,11 @@ extern "C" void app_main(void)
     nfcTask -> startTask();
     fingerprintTask -> startTask();
     wifiTask -> startTask();     // Setup Wifi Task
+
+    // Checking the heap size after task creation
+    ESP_LOGI(LOG_TAG, "Heap Size Information!");
+    ESP_LOGI(LOG_TAG, "Free heap: %u bytes", ESP.getFreeHeap());
+    ESP_LOGI(LOG_TAG, "Minimum free heap ever: %u bytes", ESP.getMinFreeHeap());
      
     // Loop Main Mechanism
     while (1) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,7 +70,7 @@ extern "C" void app_main(void)
     // Initialize the Task
     NFCTask *nfcTask = new NFCTask("NFC Task", 1, nfcService);
     FingerprintTask *fingerprintTask = new FingerprintTask("Fingerprint Task", 1, fingerprintService);
-    WifiTask *wifiTask = new WifiTask("Wifi Task", 1, wifiService, nfcQueueRequest, nfcQueueResponse, fingerprintQueueRequest, fingerprintQueueResponse);
+    WifiTask *wifiTask = new WifiTask("Wifi Task", 10, wifiService, nfcQueueRequest, nfcQueueResponse, fingerprintQueueRequest, fingerprintQueueResponse);
 
     // Setup BLE
     bleModule -> initBLE();

--- a/src/service/WifiService.cpp
+++ b/src/service/WifiService.cpp
@@ -26,6 +26,11 @@ bool WifiService::isConnected() {
     return _wifi->isConnected();
 }
 
+bool WifiService::reconnect(){
+    ESP_LOGI(WIFI_SERVICE_LOG_TAG, "Attempting to reconnect to WiFi...");
+    return _wifi->reconnect();
+}
+
 /**
  * @brief Sends request for adding new NFC access data to the backend server via HTTP POST.
  *

--- a/src/service/WifiService.h
+++ b/src/service/WifiService.h
@@ -15,6 +15,7 @@ class WifiService {
         WifiService(BLEModule *bleModule, SDCardModule *sdCardModule);
         bool setup();
         bool isConnected();
+        bool reconnect();
 
         NFCQueueResponse addNFCToServer(NFCQueueRequest nfcRequest);
         NFCQueueResponse deleteNFCFromServer(NFCQueueRequest nfcRequest);

--- a/src/tasks/WifiTask/WifiTask.cpp
+++ b/src/tasks/WifiTask/WifiTask.cpp
@@ -68,6 +68,7 @@ void WifiTask::loop(void *params){
     WifiTask* task = (WifiTask*)params;
     
     // Initialize the Wifi operation inside the task
+    vTaskDelay(1000 / portTICK_PERIOD_MS); // Give time for system to catch up
     task -> _wifiService -> setup(); 
 
     // Hold the queues message

--- a/src/tasks/WifiTask/WifiTask.cpp
+++ b/src/tasks/WifiTask/WifiTask.cpp
@@ -19,9 +19,6 @@ WifiTask::WifiTask(const char* taskName, UBaseType_t priority, WifiService* wifi
  * 
  */
 void WifiTask::startTask() {
-    // Start the WiFi operation
-    _wifiService->setup();
-
     xTaskCreatePinnedToCore(
         loop,                       // Function to run in the task
         _taskName,                  // Name of the task
@@ -70,7 +67,7 @@ bool WifiTask::resumeTask(){
 void WifiTask::loop(void *params){
     WifiTask* task = (WifiTask*)params;
     
-    // Initialize the Wifi
+    // Initialize the Wifi operation inside the task
     task -> _wifiService -> setup(); 
 
     // Hold the queues message

--- a/src/tasks/WifiTask/WifiTask.h
+++ b/src/tasks/WifiTask/WifiTask.h
@@ -38,6 +38,7 @@ class WifiTask : BaseTask {
         QueueHandle_t _fingerprintQueueRequest;
         QueueHandle_t _fingerprintQueueResponse;
         static void loop(void *parameter);
+        static void reconnect(void *parameter);
 };
 
 #endif


### PR DESCRIPTION
In this PR, I have added a fix for issue #16. In nature, with WiFi Manager, if the WiFi is disconnected, it will automatically will always try to reconnect to the last wifi credential. But there's the case that what if the source WiFi will never turn on, making it forever unable to be reconnected? That's why it needed to be able to again open the configuration portal to redirect the WiFi connection. Summary of this PR

- Added a renewal of the configuration portal in a certain amount of time(currently 3 minutes) if WiFi is disconnected from the initial state of already being connected before so we can change the WiFi credentials in the flash
- Fix the error of `[[E][WiFiClient.cpp:395] write(): fail on fd 54, errno: 11, "No more processes"`  when trying to open the WiFi configuration portal. For now, it's a **hack** as I really don't know how to do this other than this lead [here](https://github.com/espressif/arduino-esp32/issues/6129#issuecomment-2490883110) by reducing the WiFi Stack size