### PR TITLE
[Feature] Add Fingerprint LED Indicator on NFC Service

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -64,13 +64,13 @@ extern "C" void app_main(void){
 
     // Initialize the Sensor and Electrical Components
     SDCardModule *sdCardModule = new SDCardModule();
-    FingerprintSensor *adafruitFingerprintSensor = new AdafruitFingerprintSensor();
+    AdafruitFingerprintSensor *adafruitFingerprintSensor = new AdafruitFingerprintSensor();
     AdafruitNFCSensor *adafruitNFCSensor = new AdafruitNFCSensor();
     DoorRelay *doorRelay = new DoorRelay();
 
     // Initialize the Service
     FingerprintService *fingerprintService = new FingerprintService(adafruitFingerprintSensor, sdCardModule, doorRelay, bleModule, fingerprintQueueRequest, fingerprintQueueResponse);
-    NFCService *nfcService = new NFCService(adafruitNFCSensor, sdCardModule, doorRelay, bleModule, nfcQueueRequest, nfcQueueResponse);
+    NFCService *nfcService = new NFCService(adafruitNFCSensor, adafruitFingerprintSensor, sdCardModule, doorRelay, bleModule, nfcQueueRequest, nfcQueueResponse);
     SyncService *syncService = new SyncService(sdCardModule, bleModule);
     WifiService *wifiService = new WifiService(bleModule, otaModule, sdCardModule);
 

--- a/src/service/NFCService.cpp
+++ b/src/service/NFCService.cpp
@@ -47,6 +47,7 @@ bool NFCService::addNFC(const char *username, const char *visitorId, const char 
     if (!saveNFCtoSDCard){
         // Delete back the visitorId that has been saved to the server
         // As failed to save data into SD Card
+        _fingerprintSensor->activateFailedLED(FINGERPRINT_LED_BREATHING, 128, 1);
         ESP_LOGE(NFC_SERVICE_LOG_TAG, "Failed to save NFC UID %s to SD card for User: %s", uidCard, username);
         return handleError(FAILED_SAVE_NFC_ACCESS_TO_SD_CARD, username, visitorId, "Failed to save NFC UID to SD Card", false);
     }

--- a/src/service/NFCService.cpp
+++ b/src/service/NFCService.cpp
@@ -2,8 +2,8 @@
 #include "NFCService.h"
 #include <esp_log.h>
 
-NFCService::NFCService(AdafruitNFCSensor *nfcSensor, SDCardModule *sdCardModule, DoorRelay *doorRelay, BLEModule* bleModule, QueueHandle_t nfcQueueRequest, QueueHandle_t nfcQueueResponse) 
-    : _nfcSensor(nfcSensor), _sdCardModule(sdCardModule), _doorRelay(doorRelay), _bleModule(bleModule), _nfcQueueRequest(nfcQueueRequest), _nfcQueueResponse(nfcQueueResponse){
+NFCService::NFCService(AdafruitNFCSensor *nfcSensor, AdafruitFingerprintSensor *fingerprintSensor, SDCardModule *sdCardModule, DoorRelay *doorRelay, BLEModule* bleModule, QueueHandle_t nfcQueueRequest, QueueHandle_t nfcQueueResponse) 
+    : _nfcSensor(nfcSensor), _fingerprintSensor(fingerprintSensor), _sdCardModule(sdCardModule), _doorRelay(doorRelay), _bleModule(bleModule), _nfcQueueRequest(nfcQueueRequest), _nfcQueueResponse(nfcQueueResponse){
     setup();
 }
 
@@ -25,7 +25,6 @@ bool NFCService::setup() {
  */
 bool NFCService::addNFC(const char *username, const char *visitorId, const char *keyAccessId) {
     ESP_LOGI(NFC_SERVICE_LOG_TAG, "Enrolling new NFC Access User! Username %s, VisitorId %s, KeyAccessId %s", username, visitorId, keyAccessId);
-
     uint16_t timeout = 5000;
     ESP_LOGI(NFC_SERVICE_LOG_TAG, "Awaiting NFC Card Input! Timeout %d ms", timeout);
     sendbleNotification(READY_FOR_NFC_CARD_INPUT);
@@ -34,6 +33,7 @@ bool NFCService::addNFC(const char *username, const char *visitorId, const char 
     if (uidCard == nullptr || uidCard[0] == '\0') {
         ESP_LOGW(NFC_SERVICE_LOG_TAG, "No NFC card detected for User: %s!", username);
         sendbleNotification(NFC_CARD_TIMEOUT);
+        _fingerprintSensor->activateFailedLED(FINGERPRINT_LED_BREATHING, 255, 1);
         return false;
     }
     
@@ -53,6 +53,7 @@ bool NFCService::addNFC(const char *username, const char *visitorId, const char 
 
     ESP_LOGI(NFC_SERVICE_LOG_TAG, "NFC UID %s successfully saved to SD card for User: %s", uidCard, username);
     sendbleNotification(SUCCESS_REGISTERING_NFC_ACCESS);
+    _fingerprintSensor->activateSuccessLED(FINGERPRINT_LED_FLASHING, 25, 10);
     return true;
 }
 
@@ -74,11 +75,13 @@ bool NFCService::deleteNFC(const char *keyAccessId) {
 
     if (!deleteNFCfromSDCard) {
         ESP_LOGI(NFC_SERVICE_LOG_TAG, "Failed to delete NFC card for Key Access ID: %s", keyAccessId);
+        _fingerprintSensor->activateFailedLED(FINGERPRINT_LED_BREATHING, 255, 1);
         return handleDeleteError(FAILED_DELETE_NFC_ACCESS_TO_SD_CARD, "Failed to delete NFC Card from SD Card");
         
     }
     ESP_LOGI(NFC_SERVICE_LOG_TAG, "NFC UID successfully deleted to SD card for Key Access ID: %s", keyAccessId);
     sendbleNotification(SUCCESS_DELETING_NFC_ACCESS);
+    _fingerprintSensor->activateSuccessLED(FINGERPRINT_LED_FLASHING, 25, 10);
     return true;
 }
 
@@ -99,11 +102,13 @@ bool NFCService::deleteNFCsUser(const char *visitorId){
 
     if (!deleteNFCsfromSDCard) {
         ESP_LOGI(NFC_SERVICE_LOG_TAG, "Failed to delete NFC card access's for under Visitor ID: %s", visitorId);
+        _fingerprintSensor->activateFailedLED(FINGERPRINT_LED_BREATHING, 255, 1);
         return handleDeleteError(FAILED_TO_DELETE_NFCS_USER, "Failed to delete NFC Card from SD Card");
         
     }
     ESP_LOGI(NFC_SERVICE_LOG_TAG, "NFC UID user successfully deleted from SD card under visitor ID: %s", visitorId);
     sendbleNotification(SUCCESS_DELETING_NFCS_USER);
+    _fingerprintSensor->activateSuccessLED(FINGERPRINT_LED_FLASHING, 25, 10);
     return true;
 }
 
@@ -155,11 +160,12 @@ bool NFCService::authenticateAccessNFC(){
             if (xQueueSend(_nfcQueueRequest, &msg, portMAX_DELAY) != pdPASS) {
                 ESP_LOGE(NFC_SERVICE_LOG_TAG, "Failed to send NFC message to WiFi queue!");
             }
-            
+            _fingerprintSensor->activateSuccessLED(FINGERPRINT_LED_BREATHING, 128, 1);
             return true;
         }
 
         ESP_LOGI(NFC_SERVICE_LOG_TAG, "NFC Card ID %s is detected but not stored in our data system!", uidCard);
+        _fingerprintSensor->activateFailedLED(FINGERPRINT_LED_BREATHING, 255, 1);
         return false;
     }
 }

--- a/src/service/NFCService.cpp
+++ b/src/service/NFCService.cpp
@@ -33,7 +33,7 @@ bool NFCService::addNFC(const char *username, const char *visitorId, const char 
     if (uidCard == nullptr || uidCard[0] == '\0') {
         ESP_LOGW(NFC_SERVICE_LOG_TAG, "No NFC card detected for User: %s!", username);
         sendbleNotification(NFC_CARD_TIMEOUT);
-        _fingerprintSensor->activateFailedLED(FINGERPRINT_LED_BREATHING, 255, 1);
+        _fingerprintSensor->activateFailedLED(FINGERPRINT_LED_BREATHING, 128, 1);
         return false;
     }
     
@@ -53,7 +53,7 @@ bool NFCService::addNFC(const char *username, const char *visitorId, const char 
 
     ESP_LOGI(NFC_SERVICE_LOG_TAG, "NFC UID %s successfully saved to SD card for User: %s", uidCard, username);
     sendbleNotification(SUCCESS_REGISTERING_NFC_ACCESS);
-    _fingerprintSensor->activateSuccessLED(FINGERPRINT_LED_FLASHING, 25, 10);
+    _fingerprintSensor->activateSuccessLED(FINGERPRINT_LED_FLASHING, 128, 1);
     return true;
 }
 
@@ -75,13 +75,13 @@ bool NFCService::deleteNFC(const char *keyAccessId) {
 
     if (!deleteNFCfromSDCard) {
         ESP_LOGI(NFC_SERVICE_LOG_TAG, "Failed to delete NFC card for Key Access ID: %s", keyAccessId);
-        _fingerprintSensor->activateFailedLED(FINGERPRINT_LED_BREATHING, 255, 1);
+        _fingerprintSensor->activateFailedLED(FINGERPRINT_LED_BREATHING, 128, 1);
         return handleDeleteError(FAILED_DELETE_NFC_ACCESS_TO_SD_CARD, "Failed to delete NFC Card from SD Card");
         
     }
     ESP_LOGI(NFC_SERVICE_LOG_TAG, "NFC UID successfully deleted to SD card for Key Access ID: %s", keyAccessId);
     sendbleNotification(SUCCESS_DELETING_NFC_ACCESS);
-    _fingerprintSensor->activateSuccessLED(FINGERPRINT_LED_FLASHING, 25, 10);
+    _fingerprintSensor->activateSuccessLED(FINGERPRINT_LED_FLASHING, 128, 1);
     return true;
 }
 
@@ -102,13 +102,13 @@ bool NFCService::deleteNFCsUser(const char *visitorId){
 
     if (!deleteNFCsfromSDCard) {
         ESP_LOGI(NFC_SERVICE_LOG_TAG, "Failed to delete NFC card access's for under Visitor ID: %s", visitorId);
-        _fingerprintSensor->activateFailedLED(FINGERPRINT_LED_BREATHING, 255, 1);
+        _fingerprintSensor->activateFailedLED(FINGERPRINT_LED_BREATHING, 128, 1);
         return handleDeleteError(FAILED_TO_DELETE_NFCS_USER, "Failed to delete NFC Card from SD Card");
         
     }
     ESP_LOGI(NFC_SERVICE_LOG_TAG, "NFC UID user successfully deleted from SD card under visitor ID: %s", visitorId);
     sendbleNotification(SUCCESS_DELETING_NFCS_USER);
-    _fingerprintSensor->activateSuccessLED(FINGERPRINT_LED_FLASHING, 25, 10);
+    _fingerprintSensor->activateSuccessLED(FINGERPRINT_LED_FLASHING, 128, 1);
     return true;
 }
 
@@ -165,7 +165,7 @@ bool NFCService::authenticateAccessNFC(){
         }
 
         ESP_LOGI(NFC_SERVICE_LOG_TAG, "NFC Card ID %s is detected but not stored in our data system!", uidCard);
-        _fingerprintSensor->activateFailedLED(FINGERPRINT_LED_BREATHING, 255, 1);
+        _fingerprintSensor->activateFailedLED(FINGERPRINT_LED_BREATHING, 128, 1);
         return false;
     }
 }

--- a/src/service/NFCService.h
+++ b/src/service/NFCService.h
@@ -2,6 +2,7 @@
 #define NFC_SERVICE_H
 
 #include "AdafruitNFCSensor.h"
+#include "AdafruitFingerprintSensor.h"
 #include "DoorRelay.h"
 #include "StatusCodes.h"
 #include "repository/SDCardModule/SDCardModule.h"
@@ -14,7 +15,7 @@
 /// @brief Class that manages the NFC Access Control system by wrapping the functionalitites of NFC sensor, SD Card module, and the Door Relay
 class NFCService {
     public:
-        NFCService(AdafruitNFCSensor *nfcSensor, SDCardModule *sdCardModule, DoorRelay *doorRelay, BLEModule *bleModule, QueueHandle_t nfcQueueRequest, QueueHandle_t nfcQueueResponse);
+        NFCService(AdafruitNFCSensor *nfcSensor, AdafruitFingerprintSensor *fingerprintSensor, SDCardModule *sdCardModule, DoorRelay *doorRelay, BLEModule *bleModule, QueueHandle_t nfcQueueRequest, QueueHandle_t nfcQueueResponse);
         bool setup();
         bool addNFC(const char *username, const char *visitorId, const char *keyAccessId);
         bool deleteNFC(const char *keyAccessId);
@@ -31,6 +32,7 @@ class NFCService {
 
     private:
         AdafruitNFCSensor* _nfcSensor;
+        AdafruitFingerprintSensor* _fingerprintSensor;
         SDCardModule* _sdCardModule;
         DoorRelay* _doorRelay;
         BLEModule* _bleModule;


### PR DESCRIPTION
in this PR, i added an LED indicator feature to the fingerprint sensor to indicate successful authentication/registration/deletion of RFID cards. I used the LED on the fingerprint sensor because the RFID sensor does not have an LED indicator and is also hidden. With this, I resolved issue #35 